### PR TITLE
ENG-4192 changed the documentation reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make build
 
 ## Documentation
 
-Detailed [documentation](/docs/index.md) is provided. Please use this documentation for provider setup and usage.
+Detailed [documentation](https://registry.terraform.io/providers/cloudknox/cloudknox/latest/docs) is provided. Please use this documentation for provider setup and usage.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make build
 
 ## Documentation
 
-Detailed [documentation](https://registry.terraform.io/providers/cloudknox/cloudknox/latest/docs) is provided. Please use this documentation for provider setup and usage.
+Detailed [documentation](/providers/cloudknox/cloudknox/latest/docs) is provided. Please use this documentation for provider setup and usage.
 
 ## Debug
 


### PR DESCRIPTION
Description: 
Changed the GitHub documentation reference link.


- Type of change :
  - Bug fix for existing feature
